### PR TITLE
Only post to the official Slack channels on scheduled runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ env:
     - SITE_PAGE_API_URL=https://www.docs.verify.service.gov.uk/api/pages.json
     - SITE_PAGE_API_URL=https://gds-way.cloudapps.digital/api/pages.json
 
-script:
-  - bundle check || bundle install
-  - bundle exec rake notify:expired
+script: ./travis.sh

--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -64,6 +64,8 @@ class Notifier
         #{page_lines.join("\n")}
       doc
 
+      channel = ENV.fetch('OVERRIDE_SLACK_CHANNEL', channel)
+
       puts "== Message to #{channel}"
       puts message
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -118,6 +118,21 @@ RSpec.describe Notifier, vcr: true do
           }
         ])
       end
+
+      it "allows overriding the slack channel" do
+        ENV['OVERRIDE_SLACK_CHANNEL'] = '#override'
+        payloads = @notifier.message_payloads(@notifier.pages_per_channel)
+
+        expect(payloads).to match([
+          {
+            username: "Daniel the Manual Spaniel",
+            icon_emoji: ":daniel-the-manual-spaniel:",
+            text: "Hello :paw_prints:, this is your friendly manual spaniel. I've found 2 pages that will expire on or before 2018-10-12:\n\n- <https://gds-way.cloudapps.digital/standards/logging.html|How to store and query logs> (in 18 days)\n- <https://gds-way.cloudapps.digital/standards/monitoring.html|How to monitor your service> (in 18 days)\n",
+            mrkdwn: true,
+            channel: "#override",
+          }
+        ])
+      end
     end
   end
 end

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu
+
+: ${TRAVIS_EVENT_TYPE:?Not running on Travis}
+
+bundle check || bundle install
+
+case "$TRAVIS_EVENT_TYPE" in
+  pr|pull_request|push)
+    echo "Running tests and posting to #bot-testing"
+    bundle exec rspec
+    OVERRIDE_SLACK_CHANNEL="#bot-testing" bundle exec rake notify:expired
+    ;;
+  cron)
+    bundle exec rake notify:expired
+    ;;
+  *)
+    echo "TRAVIS_EVENT_TYPE was $TRAVIS_EVENT_TYPE - something's wrong :(" >/dev/stderr
+    ;;
+esac 


### PR DESCRIPTION
Currently, the spaniel runs once a day and posts to the relevant slack
channels defined by `owner_slack` in the tech docs config. It would be
nice to test that adding a site URL to the Travis config here actually
works, so on PRs and merges, Daniel will only post to #bot-testing.