### PR TITLE
Add the DCS pilot docs to Daniel's TO DO list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
     - SITE_PAGE_API_URL=https://gds-way.cloudapps.digital/api/pages.json
     - SITE_PAGE_API_URL=https://docs.publishing.service.gov.uk/api/pages.json
     - SITE_PAGE_API_URL=https://verify-team-manual.cloudapps.digital/api/pages.json
+    - SITE_PAGE_API_URL=https://dcs-pilot-docs.cloudapps.digital/api/pages.json
 
 script: ./travis.sh


### PR DESCRIPTION
## What

Have Daniel keep an eye on the DCS pilot documentation: https://dcs-pilot-docs.cloudapps.digital

## Why

The DCS team want regular reminders to review the DCS pilot documentation.