### PR TITLE
Add DCS service manual

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ env:
     - SITE_PAGE_API_URL=https://docs.publishing.service.gov.uk/api/pages.json
     - SITE_PAGE_API_URL=https://verify-team-manual.cloudapps.digital/api/pages.json
     - SITE_PAGE_API_URL=https://dcs-pilot-docs.cloudapps.digital/api/pages.json
+    - SITE_PAGE_API_URL=https://dcs-service-manual.cloudapps.digital/api/pages.json
 
 script: ./travis.sh


### PR DESCRIPTION
## What

Add the [DCS service manual](https://dcs-service-manual.cloudapps.digital/) to the tech docs monitor

## Why

The DCS team want to use Daniel the Manual Spaniel as a prompt to regularly review internal documentation.