### PR TITLE
Add GOV.UK Pay docs to Daniel's watchlist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ env:
     - SITE_PAGE_API_URL=https://verify-team-manual.cloudapps.digital/api/pages.json
     - SITE_PAGE_API_URL=https://dcs-pilot-docs.cloudapps.digital/api/pages.json
     - SITE_PAGE_API_URL=https://dcs-service-manual.cloudapps.digital/api/pages.json
+    - SITE_PAGE_API_URL=https://docs.payments.service.gov.uk/api/pages.json
 
 script: ./travis.sh


### PR DESCRIPTION
## What
Have Daniel monitor GOV.UK Pay technical documentation at https://docs.payments.service.gov.uk/.

## Why
The Pay team want regular reminders to review the documentation.