### PR TITLE
Adding Docker Hub Authentication Details

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -37,6 +37,8 @@ jobs:
             source:
               repository: ruby
               tag: 2.6.0
+              username: ((docker_hub_username))
+              password: ((docker_hub_authtoken))
           inputs:
             - name: git-master
           params:


### PR DESCRIPTION
This is to address the problem of rate limiting that docker hub is
introducing on un-authenticated accounts.