### PR TITLE
Add GovWifi's team manual

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ namespace :notify do
     "https://dcs-pilot-docs.cloudapps.digital/api/pages.json",
     "https://dcs-service-manual.cloudapps.digital/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
+    "https://govwifi-dev-docs.cloudapps.digital/api/pages.json",
   ]
 
   slack_url = ENV.fetch("SLACK_WEBHOOK_URL")


### PR DESCRIPTION
## What

Add GovWifi's team manual.

## Why

The GovWifi team wants to use Daniel the Manual Spaniel as a prompt to regularly review internal docs.
