### PR TITLE
BAU: Support limit on the number of pages notified

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ pages_urls = [
 ]
 ```
 
+If you want to limit the number of links that are posted to Slack after a single run, add this to  `limits` in the [`Rakefile`][Rakefile]
+
+```
+limits = {
+  "your-docs-site.cloudapps.digital" => 3
+}
+```
+
+The default behaviour is no limit, and the Slack message will contain all pages discovered.
+
 [Rakefile]: https://github.com/alphagov/tech-docs-monitor/blob/master/Rakefile
 
 ### General configuration

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,10 @@ namespace :notify do
     "https://docs.payments.service.gov.uk/api/pages.json",
   ]
 
+  limits = {
+    "https://dcs-service-manual.cloudapps.digital/api/pages.json" => 5
+  }
+
   slack_url = ENV.fetch("SLACK_WEBHOOK_URL")
   live = ENV.fetch("REALLY_POST_TO_SLACK", 0) == "1"
 
@@ -22,7 +26,7 @@ namespace :notify do
     notification = Notification::Expired.new
 
     pages_urls.each do |page_url|
-      Notifier.new(notification, page_url, slack_url, live).run
+      Notifier.new(notification, page_url, slack_url, live, limits.fetch(page_url, -1)).run
     end
   end
 

--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -7,11 +7,12 @@ require_relative './notification/expired'
 require_relative './notification/will_expire_by'
 
 class Notifier
-  def initialize(notification, pages_url, slack_url, live)
+  def initialize(notification, pages_url, slack_url, live, limit = -1)
     @notification = notification
     @pages_url = pages_url
     @slack_url = slack_url
     @live = !!live
+    @limit = limit
   end
 
   def run
@@ -51,10 +52,12 @@ class Notifier
 
   def message_payloads(grouped_pages)
     grouped_pages.map do |channel, pages|
-      number_of = pages.size == 1 ? @notification.singular_message : @notification.multiple_message
-      number_of = number_of % [pages.size]
 
-      page_lines = pages.map do |page|
+      page_count = @limit == -1 ? pages.size : [pages.size, @limit].min
+      notification_message = page_count == 1 ? @notification.singular_message : @notification.multiple_message
+      number_of = notification_message % [page_count]
+
+      page_lines = pages[0..page_count-1].map do |page|
         @notification.line_for(page)
       end
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -95,6 +95,28 @@ RSpec.describe Notifier, vcr: true do
           }
         ])
       end
+
+      it "limits the number of pages sent to slack" do
+          limited_notifier = Notifier.new(Notification::Expired.new, @pages_url, "", false, 3)
+          payloads = limited_notifier.message_payloads(limited_notifier.pages_per_channel)
+
+          expect(payloads).to match([
+            {
+              username: "Daniel the Manual Spaniel",
+              icon_emoji: ":daniel-the-manual-spaniel:",
+              text: "Hello :paw_prints:, this is your friendly manual spaniel. I've found 3 pages that are due for review:\n\n- <https://gds-way.cloudapps.digital/standards/supporting-services.html|Support Operations> (42 days ago)\n- <https://gds-way.cloudapps.digital/standards/dns-hosting.html|How to manage DNS records for your service> (11 days ago)\n- <https://gds-way.cloudapps.digital/standards/how-to-do-penetration-tests.html|How to do penetration tests> (11 days ago)\n",
+              mrkdwn: true,
+              channel: "#gds-way",
+            },
+            {
+              username: "Daniel the Manual Spaniel",
+              icon_emoji: ":daniel-the-manual-spaniel:",
+              text: "Hello :paw_prints:, this is your friendly manual spaniel. I've found a page that is due for review:\n\n- <https://gds-way.cloudapps.digital/standards/tracking-dependencies.html|How to manage third party software dependencies> (2862 days ago)\n",
+              mrkdwn: true,
+              channel: "@foobarx",
+            }
+          ])
+        end
     end
   end
 


### PR DESCRIPTION
Sometimes we get a lot of pages coming up for review at once.

This PR gives the ability to set a cap on the number of pages linked in Slack by the monitor so reviews can be chunked up if there's a sudden glut of pages in need of review.

The default behaviour for the monitor (with the exception of the DCS Service Manual, which provides the motivation for this PR) is unchanged.