### PR TITLE
Remove GOV.UK Developer Docs from the notify list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ namespace :notify do
   pages_urls = [
     "https://www.docs.verify.service.gov.uk/api/pages.json",
     "https://gds-way.cloudapps.digital/api/pages.json",
-    "https://docs.publishing.service.gov.uk/api/pages.json",
     "https://verify-team-manual.cloudapps.digital/api/pages.json",
     "https://dcs-pilot-docs.cloudapps.digital/api/pages.json",
     "https://dcs-service-manual.cloudapps.digital/api/pages.json",


### PR DESCRIPTION
GOV.UK no longer uses 'Daniel the Manual Spaniel', since https://github.com/alphagov/govuk-developer-docs/pull/2836 and https://github.com/alphagov/govuk-developer-docs/pull/2837 were merged.