### PR TITLE
Bump bundler from 1.7.5 to 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,4 +105,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
Bumps bundler to the same version as used in the current ruby:2.75 Docker image ([280416eb1a1c]).

I'm hoping this will fix the error running the pipeline on Concourse, where we're seeing

```
/usr/local/lib/ruby/2.7.0/rubygems.rb:277:in `find_spec_for_exe': Could not find 'bundler' (1.17.2) required by your /tmp/build/ece21583/git-master/Gemfile.lock. (Gem::GemNotFoundException)
```

[280416eb1a1c]: https://hub.docker.com/layers/ruby/library/ruby/2.7.5/images/sha256-495a68e92dc9c31d0f5b0cb114403b7d2b950d39dc1d86bfa0a72feb573cd5fc