### PR TITLE
Stop Daniel from crashing if one of the Tech Docs is down

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,8 @@ namespace :notify do
     notification = Notification::Expired.new
 
     pages_urls.each do |page_url|
+      puts "== #{page_url}"
+
       Notifier.new(notification, page_url, slack_url, live, limits.fetch(page_url, -1)).run
     end
   end
@@ -42,6 +44,8 @@ namespace :notify do
     notification = Notification::WillExpireBy.new(expire_by)
 
     pages_urls.each do |page_url|
+      puts "== #{page_url}"
+
       Notifier.new(notification, page_url, slack_url, live).run
     end
   end

--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -19,6 +19,8 @@ class Notifier
   def run
     payloads = message_payloads(pages_per_channel)
 
+    return if payloads.empty?
+
     puts "== JSON Payload:"
     puts JSON.pretty_generate(payloads)
 
@@ -59,7 +61,9 @@ class Notifier
         Page.new(data)
       }
     rescue => exception
-      raise "Notifier: could not get pages for tech docs at #{@pages_url}"
+      warn "Notifier: could not get pages for tech docs at #{@pages_url}"
+      warn exception.message
+      return []
     end
   end
 

--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -53,10 +53,14 @@ class Notifier
   end
 
   def pages
-    JSON.parse(HTTP.get(@pages_url)).map { |data|
-      data['url'] = get_absolute_url(data['url'])
-      Page.new(data)
-    }
+    begin
+      JSON.parse(HTTP.get(@pages_url)).map { |data|
+        data['url'] = get_absolute_url(data['url'])
+        Page.new(data)
+      }
+    rescue => exception
+      raise "Notifier: could not get pages for tech docs at #{@pages_url}"
+    end
   end
 
   def pages_per_channel


### PR DESCRIPTION
Currently if Notifier::run is called with a bad URL then it will raise and the program will crash unless it is caught. Instead we treat this as a recoverable error; we print to stderr that there was an error, and don't try to post to Slack, but otherwise don't raise. This means the Rakefile can continue on to other tech docs.