### PR TITLE
Added the DI team manual to the list of crawled pages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ namespace :notify do
     "https://verify-team-manual.cloudapps.digital/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
     "https://govwifi-dev-docs.cloudapps.digital/api/pages.json",
+    "https://di-team-manual.london.cloudapps.digital/api/pages.json",
   ]
 
   limits = {


### PR DESCRIPTION
This adds the current team manual url to the monitor, I'll be changing this soon as we are booted off PaaS. 