### PR TITLE
Update GOV.UK One Login Manual URL

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ namespace :notify do
     "https://verify-team-manual.cloudapps.digital/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
     "https://govwifi-dev-docs.cloudapps.digital/api/pages.json",
-    "https://di-team-manual.london.cloudapps.digital/api/pages.json",
+    "https://team-manual.account.gov.uk/api/pages.json",
   ]
 
   limits = {


### PR DESCRIPTION
As part of the great move off PaaS, GOV.UK One Login (DI) has moved our manual location and sited it on an account.gov.uk domain.

We'll want to update it here if we're still to get notifications