### PR TITLE
Tidy up

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task default: ["notify:expired"]
 
 namespace :notify do
   pages_urls = [
-    "https://gds-way.cloudapps.digital/api/pages.json",
+    "https://gds-way.digital.cabinet-office.gov.uk/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
     "https://team-manual.account.gov.uk/api/pages.json",
   ]

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,7 @@ task default: ["notify:expired"]
 
 namespace :notify do
   pages_urls = [
-    "https://www.docs.verify.service.gov.uk/api/pages.json",
     "https://gds-way.cloudapps.digital/api/pages.json",
-    "https://verify-team-manual.cloudapps.digital/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
     "https://govwifi-dev-docs.cloudapps.digital/api/pages.json",
     "https://team-manual.account.gov.uk/api/pages.json",

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ namespace :notify do
   pages_urls = [
     "https://gds-way.cloudapps.digital/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
-    "https://govwifi-dev-docs.cloudapps.digital/api/pages.json",
     "https://team-manual.account.gov.uk/api/pages.json",
   ]
 


### PR DESCRIPTION
Remove:
- Old verify docs URLs, long gone
- GOV.UK Wifi docs, PaaS that hosted this is gone

House keeping exercise, but also noting how messy these make the github action logs when you're trying to debug other things:
https://github.com/alphagov/tech-docs-monitor/actions/runs/7710897137/job/21027659379