### PR TITLE
add GovWifi back into the fold

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,8 @@ namespace :notify do
     "https://gds-way.digital.cabinet-office.gov.uk/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
     "https://team-manual.account.gov.uk/api/pages.json",
+    "https://dev-docs.wifi.service.gov.uk/",
+    "https://docs.wifi.service.gov.uk/",
   ]
 
   limits = {

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,8 @@ namespace :notify do
     "https://gds-way.digital.cabinet-office.gov.uk/api/pages.json",
     "https://docs.payments.service.gov.uk/api/pages.json",
     "https://team-manual.account.gov.uk/api/pages.json",
-    "https://dev-docs.wifi.service.gov.uk/",
-    "https://docs.wifi.service.gov.uk/",
+    "https://dev-docs.wifi.service.gov.uk/api/pages.json",
+    "https://docs.wifi.service.gov.uk/api/pages.json",
   ]
 
   limits = {


### PR DESCRIPTION
### What
Add GovWifi 2 x passive documentation websites back into this tool.

### Why
We need to keep our docs up to date and this tool is very useful for reminding us.