### PR TITLE
Change schedule to be weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v1
         with:
-          path: vendor/bundle
-          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: bundle
-      - run: bundle install --jobs 4 --retry 3 --deployment
+          bundler-cache: true
       - run: bundle exec rspec

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '5 12 * * 1-5'  # 12:05 UTC, Monday to Friday
+    - cron: '5 12 * * 3'  # 12:05 UTC, Weekly on a Wednesday
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
With our current ways of working, it's hard to see who benefits from a daily rather than a weekly reminder.

This PR changes the schedule of posts to be once every Wednesday, at around midday.