### PR TITLE
GW-1876: Strip out any mention of heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+.idea/*

--- a/app.json
+++ b/app.json
@@ -17,10 +17,5 @@
   },
   "addons": [
     "scheduler:standard"
-  ],
-  "buildpacks": [
-    {
-      "url": "https://github.com/heroku/heroku-buildpack-ruby.git"
-    }
   ]
 }


### PR DESCRIPTION
What
Remove Heroku reference

Why
Keeping deprecated or irrelevant code in codebase is bad practice, causes mental overhead and can potentially cause security vulnerabilities.

Link to Jira card (if applicable):
[GW-1876](https://technologyprogramme.atlassian.net/browse/GW-1876)

[GW-1876]: https://technologyprogramme.atlassian.net/browse/GW-1876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ