### PR TITLE
Revert "Implement Daniel the Manual Spaniel but hardcoded Slack channel for GovWifi"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -18,4 +18,3 @@ jobs:
         env:
           REALLY_POST_TO_SLACK: ${{ (github.event_name == 'schedule') && 1 || 0 }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tech-Docs Template - page expiry notifier
+# Tech Docs Template - page expiry notifier
 
 This repo is part of the [tech-docs-template][template], and is used in
 conjunction with the [page expiry feature][expiry] that is part of the

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,9 @@ task default: ["notify:expired"]
 
 namespace :notify do
   pages_urls = [
+    "https://gds-way.digital.cabinet-office.gov.uk/api/pages.json",
+    "https://docs.payments.service.gov.uk/api/pages.json",
+    "https://team-manual.account.gov.uk/api/pages.json",
     "https://dev-docs.wifi.service.gov.uk/api/pages.json",
     "https://docs.wifi.service.gov.uk/api/pages.json",
   ]
@@ -23,6 +26,7 @@ namespace :notify do
   desc "Notifies of all pages which have expired"
   task :expired do
     notification = Notification::Expired.new
+
     pages_urls.each do |page_url|
       puts "== #{page_url}"
 

--- a/lib/notifier.rb
+++ b/lib/notifier.rb
@@ -95,8 +95,7 @@ class Notifier
         #{page_lines.join("\n")}
       doc
 
-      # channel = ENV.fetch('OVERRIDE_SLACK_CHANNEL', channel)
-      channel = "#govwifi"
+      channel = ENV.fetch('OVERRIDE_SLACK_CHANNEL', channel)
       username = ENV.fetch('OVERRIDE_SLACK_USERNAME', "Daniel the Manual Spaniel")
       icon_emoji = ENV.fetch('OVERRIDE_SLACK_ICON_EMOJI', ":daniel-the-manual-spaniel:")
 


### PR DESCRIPTION
Reverts alphagov/tech-docs-monitor#68

This PR appears to have been for a [fork](https://github.com/GovWifi/tech-docs-monitor), based on the description and  because it changes a lot of configuration to make it more specific to that fork.