### PR TITLE
Remove dependency on Octokit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby File.read('.ruby-version').strip
 gem 'activesupport'
 gem 'chronic'
 gem 'http'
-gem 'octokit'
 gem 'rake'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,29 +27,6 @@ GEM
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
     drb (2.2.3)
-    faraday (1.10.5)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.1)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.2.0)
-      multipart-post (~> 2.0)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.4)
     hashdiff (1.2.1)
     http (6.0.3)
       http-cookie (~> 1.0)
@@ -64,9 +41,6 @@ GEM
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
-    multipart-post (2.4.1)
-    octokit (4.12.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
     prism (1.9.0)
     public_suffix (7.0.5)
     rake (13.4.2)
@@ -84,10 +58,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    ruby2_keywords (0.0.5)
-    sawyer (0.8.2)
-      addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
     securerandom (0.4.1)
     timecop (0.9.1)
     tzinfo (2.0.6)
@@ -106,7 +76,6 @@ DEPENDENCIES
   activesupport
   chronic
   http
-  octokit
   rake
   rexml
   rspec


### PR DESCRIPTION
The [Octokit] gem is not used anywhere in this codebase; it appears there was originally a GitHub integration planned, but it was removed in commit 13f460e; but removing this dependency was missed.

This commit removes octokit from our Gemfile so we're not downloading and installing unused code, and so we don't need to worry about keeping the dependency up-to-date.

[Octokit]: https://github.com/octokit/octokit.rb
